### PR TITLE
Predictive background feed refresh scheduling

### DIFF
--- a/Raul/App/RaulApp.swift
+++ b/Raul/App/RaulApp.swift
@@ -143,7 +143,7 @@ struct RaulApp: App {
             CrashBreadcrumbs.shared.record("scene_phase_changed", details: "\(phase)")
             switch phase {
             case .background:
-                scheduleFeedRefresh()
+                Task { await scheduleFeedRefresh() }
                 scheduleFeedProcessing()
                 scheduleStorageCleanup()
                 guard modelContainerManager.preparedContainer != nil else {
@@ -334,20 +334,38 @@ struct RaulApp: App {
         UserDefaults.standard.setValue(Date().formatted(), forKey: "LastBackgroundProcess")
     }
     
-    func scheduleFeedRefresh() {
+
+    private func predictedFeedRefreshBeginDate() async -> Date? {
+        let fallback = Date(timeIntervalSinceNow: BackgroundTaskConfiguration.feedRefreshInterval)
+        guard let container = await MainActor.run(body: { modelContainerManager.preparedContainer }) else {
+            return fallback
+        }
+
+        guard let predicted = await SubscriptionManager(modelContainer: container).nextPredictedFeedRefreshDate() else {
+            return fallback
+        }
+
+        let minimumDelay = Date(timeIntervalSinceNow: 15 * 60)
+        let maximumDelay = fallback
+        return min(max(predicted, minimumDelay), maximumDelay)
+    }
+
+    func scheduleFeedRefresh() async {
 #if os(iOS)
         // this should replace scheduleAppRefresh
         CrashBreadcrumbs.shared.record("schedule_feed_refresh_requested")
         BasicLogger.shared.log("schedule checkFeedUpdates")
+        let earliestBeginDate = await predictedFeedRefreshBeginDate()
         let request = BGAppRefreshTaskRequest(identifier: BackgroundTaskConfiguration.feedRefreshIdentifier)
-        request.earliestBeginDate = Date(timeIntervalSinceNow: BackgroundTaskConfiguration.feedRefreshInterval)
-        
-        do{
-            try BGTaskScheduler.shared.submit(request)
-            CrashBreadcrumbs.shared.record("schedule_feed_refresh_submitted")
+        request.earliestBeginDate = earliestBeginDate
 
-        }catch{
-            // print(error)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            CrashBreadcrumbs.shared.record(
+                "schedule_feed_refresh_submitted",
+                details: earliestBeginDate.map { "earliest=\($0)" }
+            )
+        } catch {
             CrashBreadcrumbs.shared.record("schedule_feed_refresh_failed", details: error.localizedDescription)
             BasicLogger.shared.log(error.localizedDescription)
         }

--- a/Raul/Features/Search/Services/SubscriptionManager.swift
+++ b/Raul/Features/Search/Services/SubscriptionManager.swift
@@ -535,6 +535,54 @@ actor SubscriptionManager:NSObject{
     }
 
     
+
+    func nextPredictedFeedRefreshDate(after now: Date = Date()) async -> Date? {
+        fetchData()
+        return podcasts
+            .filter { $0.metaData?.isSubscribed != false }
+            .compactMap { PodcastReleasePredictor.prediction(for: $0, after: now)?.refreshStart }
+            .min()
+    }
+
+    private func podcastsPrioritizedForBackgroundRefresh(now: Date) -> [Podcast] {
+        podcasts
+            .filter { $0.metaData?.isSubscribed != false }
+            .sorted { lhs, rhs in
+                let lhsPrediction = PodcastReleasePredictor.prediction(for: lhs, after: now)
+                let rhsPrediction = PodcastReleasePredictor.prediction(for: rhs, after: now)
+                let lhsScore = backgroundRefreshScore(for: lhs, prediction: lhsPrediction, now: now)
+                let rhsScore = backgroundRefreshScore(for: rhs, prediction: rhsPrediction, now: now)
+                if lhsScore != rhsScore { return lhsScore > rhsScore }
+
+                let lhsCheck = lhs.metaData?.feedUpdateCheckDate ?? .distantPast
+                let rhsCheck = rhs.metaData?.feedUpdateCheckDate ?? .distantPast
+                if lhsCheck != rhsCheck { return lhsCheck < rhsCheck }
+                return (lhs.metaData?.lastRefresh ?? .distantPast) < (rhs.metaData?.lastRefresh ?? .distantPast)
+            }
+    }
+
+    private func backgroundRefreshScore(
+        for podcast: Podcast,
+        prediction: PodcastReleasePredictor.Prediction?,
+        now: Date
+    ) -> Int {
+        guard let prediction else { return 0 }
+        let lastCheck = podcast.metaData?.feedUpdateCheckDate ?? .distantPast
+        if lastCheck >= prediction.refreshStart, lastCheck <= prediction.refreshEnd {
+            return 25
+        }
+        if now >= prediction.refreshStart, now <= prediction.refreshEnd {
+            return 100
+        }
+        if now > prediction.refreshEnd {
+            return 75
+        }
+        let secondsUntilWindow = prediction.refreshStart.timeIntervalSince(now)
+        if secondsUntilWindow <= 60 * 60 { return 60 }
+        if secondsUntilWindow <= 3 * 60 * 60 { return 40 }
+        return 10
+    }
+
     func bgupdateFeeds(reason: FeedRefreshReason = .foregroundQuiet) async{
         guard await FeedRefreshRunCoordinator.shared.begin() else {
             CrashBreadcrumbs.shared.record("bgupdate_feeds_skipped", details: "reason=already_running")
@@ -562,9 +610,9 @@ actor SubscriptionManager:NSObject{
             maxRuntime = 25
             perPodcastRuntimeLimit = 7
         case .processing:
-            maxPodcastsPerRun = 12
-            maxRuntime = 120
-            perPodcastRuntimeLimit = 12
+            maxPodcastsPerRun = Int.max
+            maxRuntime = 600
+            perPodcastRuntimeLimit = 20
         }
 
         setLastRefreshDate()
@@ -578,14 +626,7 @@ actor SubscriptionManager:NSObject{
             details: "reason=\(reason),podcasts=\(podcasts.count),limit=\(maxPodcastsPerRun)"
         )
 
-        let sortedPodcasts = podcasts
-            .filter { $0.metaData?.isSubscribed != false }
-            .sorted { lhs, rhs in
-                let lhsCheck = lhs.metaData?.feedUpdateCheckDate ?? .distantPast
-                let rhsCheck = rhs.metaData?.feedUpdateCheckDate ?? .distantPast
-                if lhsCheck != rhsCheck { return lhsCheck < rhsCheck }
-                return (lhs.metaData?.lastRefresh ?? .distantPast) < (rhs.metaData?.lastRefresh ?? .distantPast)
-            }
+        let sortedPodcasts = podcastsPrioritizedForBackgroundRefresh(now: startedAt)
 
         for podcast in sortedPodcasts {
             if processed >= maxPodcastsPerRun {
@@ -711,5 +752,89 @@ extension String {
         escaped = escaped.replacingOccurrences(of: "\"", with: "&quot;")
         escaped = escaped.replacingOccurrences(of: "'", with: "&apos;")
         return escaped
+    }
+}
+
+struct PodcastReleasePredictor {
+    struct Prediction {
+        let releaseDate: Date
+        let refreshStart: Date
+        let refreshEnd: Date
+    }
+
+    private static let calendar = Calendar.autoupdatingCurrent
+    private static let maximumEpisodes = 12
+    private static let minimumEpisodes = 3
+    private static let refreshLeadTime: TimeInterval = 30 * 60
+    private static let refreshFollowUpTime: TimeInterval = 3 * 60 * 60
+    private static let minimumInterval: TimeInterval = 6 * 60 * 60
+    private static let maximumInterval: TimeInterval = 14 * 24 * 60 * 60
+
+    static func prediction(for podcast: Podcast, after now: Date) -> Prediction? {
+        let dates = (podcast.episodes ?? [])
+            .compactMap(\.publishDate)
+            .filter { $0 < now.addingTimeInterval(24 * 60 * 60) }
+            .sorted(by: >)
+            .prefix(maximumEpisodes)
+
+        guard dates.count >= minimumEpisodes else { return nil }
+
+        let sortedAscending = dates.sorted()
+        let intervals = zip(sortedAscending.dropFirst(), sortedAscending)
+            .map { newer, older in newer.timeIntervalSince(older) }
+            .filter { $0 >= minimumInterval && $0 <= maximumInterval }
+
+        guard intervals.count >= minimumEpisodes - 1 else { return nil }
+
+        let interval = median(intervals)
+        var nextRelease = sortedAscending.last!.addingTimeInterval(interval)
+        while nextRelease <= now.addingTimeInterval(-refreshFollowUpTime) {
+            nextRelease = nextRelease.addingTimeInterval(interval)
+        }
+
+        if let anchored = weekdayAndTimeAnchoredDate(from: Array(sortedAscending), near: nextRelease, after: now) {
+            nextRelease = anchored
+        }
+
+        return Prediction(
+            releaseDate: nextRelease,
+            refreshStart: nextRelease.addingTimeInterval(-refreshLeadTime),
+            refreshEnd: nextRelease.addingTimeInterval(refreshFollowUpTime)
+        )
+    }
+
+    private static func median(_ values: [TimeInterval]) -> TimeInterval {
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    private static func weekdayAndTimeAnchoredDate(from dates: [Date], near estimate: Date, after now: Date) -> Date? {
+        let grouped = Dictionary(grouping: dates) { calendar.component(.weekday, from: $0) }
+        guard let (weekday, weekdayDates) = grouped.max(by: { $0.value.count < $1.value.count }), weekdayDates.count >= 2 else {
+            return nil
+        }
+
+        let minuteOfDayValues = weekdayDates.map {
+            let components = calendar.dateComponents([.hour, .minute], from: $0)
+            return (components.hour ?? 0) * 60 + (components.minute ?? 0)
+        }
+        let minuteOfDay = Int(median(minuteOfDayValues.map(TimeInterval.init)))
+
+        var components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: estimate)
+        components.weekday = weekday
+        components.hour = minuteOfDay / 60
+        components.minute = minuteOfDay % 60
+        components.second = 0
+
+        guard var anchored = calendar.date(from: components) else { return nil }
+        let interval = max(median(zip(dates.dropFirst(), dates).map { $0.timeIntervalSince($1) }), 24 * 60 * 60)
+        while anchored <= now.addingTimeInterval(-refreshFollowUpTime) {
+            anchored = anchored.addingTimeInterval(interval)
+        }
+        return anchored
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce unnecessary background refreshes by predicting the next episode release window per podcast and focusing refreshes around that time. 
- Tighten BGAppRefresh timing to run closer to predicted publish windows while preserving the existing hourly fallback. 
- Allow BGProcessing runs that can run longer than 30 seconds to attempt refreshing all subscribed podcasts. 

### Description
- Added `PodcastReleasePredictor` which estimates a podcast's next release date and a refresh window from recent episode `publishDate` values and weekday/time anchoring (new code in `Raul/Features/Search/Services/SubscriptionManager.swift`).
- Exposed `nextPredictedFeedRefreshDate()` and added `podcastsPrioritizedForBackgroundRefresh(...)` plus `backgroundRefreshScore(...)` so `bgupdateFeeds(...)` prioritizes podcasts that are inside or near their predicted refresh window (changes in `SubscriptionManager.swift`).
- Expanded the `.processing` case in `bgupdateFeeds` to allow larger runs (`maxPodcastsPerRun = Int.max`, `maxRuntime = 600`, `perPodcastRuntimeLimit = 20`) so BGProcessing runs can try refreshing all subscriptions when allowed (changed in `SubscriptionManager.swift`).
- Modified feed refresh scheduling in the app to consult predictions before submitting a `BGAppRefreshTaskRequest`; `scheduleFeedRefresh()` is now async and uses a `predictedFeedRefreshBeginDate()` that clamps the earliest begin date between 15 minutes and the existing hourly fallback, and records the chosen earliest date (changes in `Raul/App/RaulApp.swift`).
- Updated the scene-phase background transition to call the now-async `scheduleFeedRefresh()` without blocking the handler by launching it in a `Task` (change in `Raul/App/RaulApp.swift`).

### Testing
- `git diff --check` completed without issues.
- `swift test` was attempted but failed because there is no `Package.swift` in this environment for SwiftPM testing (automated test runner unavailable here).
- `xcodebuild -list -project PodcastClient.xcodeproj` was attempted but failed because `xcodebuild` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38c2cb8a5c8320bb80962d85f92417)