### PR TITLE
Speed up skipped chapter transitions by precomputing skip plan

### DIFF
--- a/Raul/Features/Player/Classes/Player.swift
+++ b/Raul/Features/Player/Classes/Player.swift
@@ -186,6 +186,7 @@ class Player {
     private var hasStartedRecovery = false
     private var finishingEpisodeURL: URL?
     private var isSkippingChapters = false
+    private var chapterSkipPlan = ChapterSkipPlan(entries: [])
     private let chapterBoundaryTolerance: TimeInterval = 0.35
     private var playbackPowerMode: PlaybackPowerMode = .foreground
     private var reduceSilenceGapsEnabled = false
@@ -754,6 +755,7 @@ class Player {
     private func updateChapters() {
         guard let currentEpisode else {
             chapters = []
+            chapterSkipPlan = ChapterSkipPlan(entries: [])
             currentChapter = nil
             nextChapter = nil
             configureChapterBoundaryObserver()
@@ -761,15 +763,14 @@ class Player {
         }
 
         chapters = currentEpisode.preferredChapters
+        rebuildChapterSkipPlan()
         configureChapterBoundaryObserver()
         RemoteCommandCenter.shared.updateSkipIntervals()
     }
 
     private func configureChapterBoundaryObserver() {
-        let chapterStartTimes = (chapters ?? [])
-            .compactMap(\.start)
-            .filter { $0.isFinite && $0 > 0 }
-            .sorted()
+        let chapterStartTimes = chapterSkipPlan.boundaryTimes
+            .filter { $0 > 0 }
             .map { CMTime(seconds: $0, preferredTimescale: 600) }
 
         Task { [weak self] in
@@ -780,6 +781,17 @@ class Player {
                 }
             }
         }
+    }
+
+    private func rebuildChapterSkipPlan() {
+        chapterSkipPlan = ChapterSkipPlan(entries: (chapters ?? []).compactMap { chapter in
+            guard let start = chapter.start else { return nil }
+            return ChapterSkipPlan.Entry(
+                id: chapter.uuid,
+                start: start,
+                shouldPlay: chapter.shouldPlay
+            )
+        })
     }
 
     private func handleChapterBoundary() async {
@@ -814,11 +826,6 @@ class Player {
         }
 
         currentChapter = playingChapter
-        if let currentChapterID = currentChapter?.uuid {
-            Task {
-                currentChapter?.shouldPlay = await chapterActor?.shouldPlayChapter(currentChapterID) ?? true
-            }
-        }
         chapterProgress = 0.0
         updateChapterProgress()
         Task {
@@ -1901,62 +1908,34 @@ class Player {
 
     private func skipOverChapters() async {
         guard isSkippingChapters == false else { return }
-        guard let currentChapter else { return }
-
-        guard await shouldSkip(chapter: currentChapter) else { return }
+        guard let segment = chapterSkipPlan.segment(at: playPosition) else { return }
 
         isSkippingChapters = true
         defer { isSkippingChapters = false }
 
-        await skipOverChaptersContinuing()
-    }
-
-    private func skipOverChaptersContinuing() async {
-        guard let currentChapter else { return }
-
-        guard await shouldSkip(chapter: currentChapter) else { return }
-
-        if let id = currentChapter.uuid {
-            let chapterActor = self.chapterActor
+        let chapterActor = self.chapterActor
+        for id in segment.chapterIDs {
             Task.detached(priority: .background) {
                 await chapterActor?.markChapterAsSkipped(id)
             }
         }
-        let currentChapterStart = currentChapter.start ?? playPosition
-        guard let nextChapter = chapters?.first(where: { ($0.start ?? 0) > currentChapterStart + .ulpOfOne })
-        else {
+
+        guard let resumeAt = segment.resumeAt else {
             handlePlaybackFinished()
             return
         }
 
-        let start = nextChapter.start ?? 0
-        guard start < (currentEpisode?.duration ?? .greatestFiniteMagnitude) else {
+        guard resumeAt < (currentEpisode?.duration ?? .greatestFiniteMagnitude) else {
             handlePlaybackFinished()
             return
         }
 
-        // Await the seek
-        await jumpTo(time: start)
-
-        // After the seek, update and re-check
-        await skipOverChaptersContinuing()
-    }
-
-    private func shouldSkip(chapter: Marker) async -> Bool {
-        if chapter.shouldPlay == false {
-            return true
-        }
-
-        if let id = chapter.uuid,
-           let persistedShouldPlay = await chapterActor?.shouldPlayChapter(id) {
-            chapter.shouldPlay = persistedShouldPlay
-        }
-
-        return chapter.shouldPlay == false
+        await jumpTo(time: resumeAt)
     }
 
     func chapterPlaybackPreferenceChanged(_ chapter: Marker, shouldPlay: Bool) {
         chapter.shouldPlay = shouldPlay
+        rebuildChapterSkipPlan()
         configureChapterBoundaryObserver()
 
         if let id = chapter.uuid {

--- a/Raul/Features/Player/Models/ChapterSkipPlan.swift
+++ b/Raul/Features/Player/Models/ChapterSkipPlan.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Precomputed seek targets for chapter runs that the listener disabled.
+///
+/// Keeping this plan in memory lets the player's boundary callback seek immediately,
+/// rather than fetching every chapter from SwiftData as playback crosses its start.
+struct ChapterSkipPlan: Equatable {
+    struct Entry {
+        let id: UUID?
+        let start: TimeInterval
+        let shouldPlay: Bool
+    }
+
+    struct Segment: Equatable {
+        let start: TimeInterval
+        let resumeAt: TimeInterval?
+        let chapterIDs: [UUID]
+
+        func contains(_ position: TimeInterval) -> Bool {
+            position >= start && (resumeAt.map { position < $0 } ?? true)
+        }
+    }
+
+    let segments: [Segment]
+
+    init(entries: [Entry]) {
+        let chapters = entries
+            .filter { $0.start.isFinite && $0.start >= 0 }
+            .sorted { $0.start < $1.start }
+
+        var result: [Segment] = []
+        var index = 0
+        while index < chapters.count {
+            guard chapters[index].shouldPlay == false else {
+                index += 1
+                continue
+            }
+
+            let start = chapters[index].start
+            var skippedIDs: [UUID] = []
+            while index < chapters.count, chapters[index].shouldPlay == false {
+                if let id = chapters[index].id {
+                    skippedIDs.append(id)
+                }
+                index += 1
+            }
+
+            result.append(Segment(
+                start: start,
+                resumeAt: index < chapters.count ? chapters[index].start : nil,
+                chapterIDs: skippedIDs
+            ))
+        }
+        segments = result
+    }
+
+    var boundaryTimes: [TimeInterval] {
+        segments.map(\.start)
+    }
+
+    func segment(at position: TimeInterval) -> Segment? {
+        segments.last { $0.start <= position && $0.contains(position) }
+    }
+}

--- a/UpNextTests/ChapterSkipPlanTests.swift
+++ b/UpNextTests/ChapterSkipPlanTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import UpNext
+
+final class ChapterSkipPlanTests: XCTestCase {
+    func testConsecutiveSkippedChaptersBecomeOneImmediateSeek() throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let plan = ChapterSkipPlan(entries: [
+            .init(id: nil, start: 0, shouldPlay: true),
+            .init(id: firstID, start: 10, shouldPlay: false),
+            .init(id: secondID, start: 20, shouldPlay: false),
+            .init(id: nil, start: 35, shouldPlay: true)
+        ])
+
+        XCTAssertEqual(plan.boundaryTimes, [10])
+        let segment = try XCTUnwrap(plan.segment(at: 10))
+        XCTAssertEqual(segment.resumeAt, 35)
+        XCTAssertEqual(segment.chapterIDs, [firstID, secondID])
+        XCTAssertNotNil(plan.segment(at: 34.99))
+        XCTAssertNil(plan.segment(at: 35))
+    }
+
+    func testChangingSelectionsBuildsDifferentBoundariesAndTargets() throws {
+        let selected = ChapterSkipPlan(entries: [
+            .init(id: nil, start: 0, shouldPlay: true),
+            .init(id: nil, start: 10, shouldPlay: false),
+            .init(id: nil, start: 20, shouldPlay: true)
+        ])
+        let deselected = ChapterSkipPlan(entries: [
+            .init(id: nil, start: 0, shouldPlay: true),
+            .init(id: nil, start: 10, shouldPlay: false),
+            .init(id: nil, start: 20, shouldPlay: false)
+        ])
+
+        XCTAssertEqual(try XCTUnwrap(selected.segment(at: 10)).resumeAt, 20)
+        XCTAssertNil(try XCTUnwrap(deselected.segment(at: 10)).resumeAt)
+    }
+
+    func testInvalidChapterStartsAreIgnoredAndEntriesAreSorted() {
+        let plan = ChapterSkipPlan(entries: [
+            .init(id: nil, start: 30, shouldPlay: false),
+            .init(id: nil, start: .nan, shouldPlay: false),
+            .init(id: nil, start: 10, shouldPlay: false),
+            .init(id: nil, start: 20, shouldPlay: true)
+        ])
+
+        XCTAssertEqual(plan.boundaryTimes, [10, 30])
+        XCTAssertEqual(plan.segment(at: 10)?.resumeAt, 20)
+        XCTAssertNil(plan.segment(at: 30)?.resumeAt)
+    }
+}


### PR DESCRIPTION
### Motivation

- Skipping chapters currently performs runtime lookups and repeated seeks as playback crosses chapter boundaries, which adds latency and work on the playback path.
- The change aims to identify skip/resume positions ahead of time so the player can seek immediately when hitting a disabled chapter range.

### Description

- Add a new in-memory `ChapterSkipPlan` to precompute contiguous disabled-chapter segments (start, resume target, and affected chapter IDs) in `Raul/Features/Player/Models/ChapterSkipPlan.swift`.
- Rebuild the skip plan when chapters are updated or when a chapter’s playback preference changes, and use the plan to drive boundary observers instead of querying the chapter list at each boundary in `Raul/Features/Player/Classes/Player.swift`.
- Replace the recursive per-chapter seek flow with a single direct seek to the cached resume position and asynchronously persist skipped state (marking chapter IDs as skipped off the critical playback path) in `Player.swift`.
- Remove the synchronous SwiftData lookup that populated `currentChapter?.shouldPlay` on chapter change to avoid blocking the main playback updates. 
- Add unit coverage for the skip-plan behavior in `UpNextTests/ChapterSkipPlanTests.swift` (consecutive skips, preference changes, sorting/invalid timestamps, and final skipped chapters).

### Testing

- `swiftc -typecheck Raul/Features/Player/Models/ChapterSkipPlan.swift` executed and succeeded. 
- `git diff --check` executed and reported no issues. 
- `xcodebuild -project 'Up Next.xcodeproj' -scheme UpNext -showdestinations` was attempted but unavailable in this environment (tooling not installed), so full Xcode build/tests were not run.
- Unit tests for the new plan were added at `UpNextTests/ChapterSkipPlanTests.swift` but were not executed in this Linux environment due to missing Xcode/tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9845e192b083209349bc18e03d5887)