### PR TITLE
Generate broader, advertisement-aware AI chapters

### DIFF
--- a/Raul/Features/Chapters/Models/AIChapter.swift
+++ b/Raul/Features/Chapters/Models/AIChapter.swift
@@ -26,7 +26,9 @@ private struct TranscriptChunkGenerationResult: Sendable {
 }
 
 actor AIChapterGenerator{
-    private let maxChaptersPerChunk = 4
+    /// This is deliberately low: a chapter should describe a substantial section of
+    /// an episode rather than every conversational turn inside that section.
+    private let maxChaptersPerChunk = 2
     
     
     
@@ -37,6 +39,18 @@ actor AIChapterGenerator{
         
         @Guide(description: "The timecode of the chapter in the format hh:mm:ss")
         var timecode: String
+    }
+
+    @Generable(description: "A broad podcast chapter boundary")
+    private struct TranscriptAIChapter {
+        @Guide(description: "A short description of the broad topic, without a chapter number or advertisement prefix")
+        var title: String
+
+        @Guide(description: "The timecode where this section begins, in the format hh:mm:ss")
+        var timecode: String
+
+        @Guide(description: "True only when this boundary begins paid advertising, a sponsor message, or a self-promotion break")
+        var isAdvertisement: Bool
     }
     
     func extractChaptersFromText(_ text: String) async -> [String:String] {
@@ -111,11 +125,17 @@ actor AIChapterGenerator{
 
         let instructions = """
            You are a podcast chapter generator.
-           Given transcript lines with timestamps, produce a sparse list of chapter boundaries.
-           Create a chapter when the topic clearly changes or an advertisement / sponsor segment begins.
-           Make advertisement sections explicit chapters so they can be skipped later.
-           Return at most 4 chapters for this chunk, ideally 1 to 3.
-           Only keep the strongest topic shifts or ad / sponsor breaks.
+           Understand the transcript in its own language, but produce only a sparse outline of broad topic blocks.
+           Group introductions, examples, questions, tangents, and related subtopics into the surrounding main topic.
+           A normal chapter should usually cover at least 8 to 15 minutes. Do not add a boundary merely because the speaker changes or a new point is made.
+           Return at most 2 boundaries for this chunk and return none when it only continues the current broad topic.
+
+           Advertising is the exception to the minimum duration rule. Recognize paid ads, sponsor reads, promotions, and self-promotion semantically in EVERY language, even when no English advertising words occur.
+           Set isAdvertisement=true at the exact beginning of every advertisement block. Put only the advertiser or a short description in title; the app adds the required "advertisement: " prefix.
+           An advertisement chapter must span the COMPLETE uninterrupted advertisement block. At the exact point editorial content resumes, always add a normal boundary with isAdvertisement=false, even when the prior editorial topic resumes and even when the advertisement crosses a chunk boundary.
+           Do not split one advertisement containing several sponsors or offers into multiple chapters unless editorial content occurs between them.
+
+           Outside advertisement boundaries, keep only unmistakable changes between broad main topics.
            Do not create chapters for every line, do not output continuation entries, and keep titles short (max 8 words).
            Use the timestamp where the new section starts.
            The transcript below is one chunk from a longer episode. Only return chapters that begin inside this chunk.
@@ -126,16 +146,16 @@ actor AIChapterGenerator{
         let usesExactTokenCounting: Bool
         if #available(iOS 26.4, macOS 26.4, *) {
             usesExactTokenCounting = true
-            chunkBudget = 1600
+            chunkBudget = 2400
         } else {
             usesExactTokenCounting = false
-            chunkBudget = 800
+            chunkBudget = 1600
         }
 
         let chunks = await chunkTranscriptLines(orderedTranscriptLines, tokenBudget: chunkBudget, model: model)
 
         #if DEBUG
-        print("AI transcript chapter generation will process \(orderedTranscriptLines.count) transcript line(s) in \(chunks.count) chunk(s) using \(usesExactTokenCounting ? "exact" : "estimated") token counting and will keep up to \(maxChaptersPerChunk) chapter(s) per chunk.")
+        print("AI transcript chapter generation will process \(orderedTranscriptLines.count) transcript line(s) in \(chunks.count) chunk(s) using \(usesExactTokenCounting ? "exact" : "estimated") token counting and will keep up to \(maxChaptersPerChunk) broad chapter boundary/boundaries per chunk.")
         #endif
 
         var mergedChapters: [String: String] = [:]
@@ -465,14 +485,17 @@ actor AIChapterGenerator{
             let continuityPrompt = promptPrefix(for: previousChapterContext)
             let response = try await session.respond(
                 to: continuityPrompt.isEmpty ? chunk.prompt : "\(continuityPrompt)\n\n\(chunk.prompt)",
-                generating: [AIChapter].self,
+                generating: [TranscriptAIChapter].self,
                 includeSchemaInPrompt: false,
                 options: options
             )
 
             let candidates = response.content.compactMap { $0 }
-            let validChapters: [(String, String)] = candidates.compactMap { (chapter: AIChapter) -> (String, String)? in
-                let title = normalizedChapterTitle(chapter.title)
+            let validChapters: [(String, String)] = candidates.compactMap { (chapter: TranscriptAIChapter) -> (String, String)? in
+                let title = normalizedTranscriptChapterTitle(
+                    chapter.title,
+                    isAdvertisement: chapter.isAdvertisement
+                )
                 guard title.isEmpty == false,
                       title.lowercased() != "continuation",
                       chapter.timecode.durationAsSeconds != nil else {
@@ -568,7 +591,25 @@ actor AIChapterGenerator{
         Continuity context from the previous chunk:
         - Previous chunk ended with chapter "\(previousChapterContext.title)" at \(previousChapterContext.timecode).
         - If this chunk continues that same topic, keep it as the same chapter until there is a clear topic change or ad break.
+        - A title beginning with "advertisement:" means the chunk may begin inside an advertisement. Do not add another ad boundary; add a normal boundary exactly when the complete advertisement ends.
         """
+    }
+
+    private func normalizedTranscriptChapterTitle(_ title: String, isAdvertisement: Bool) -> String {
+        var normalizedTitle = normalizedChapterTitle(title)
+        guard isAdvertisement else { return normalizedTitle }
+
+        // The model classifies ads independently of the transcript language. Enforce
+        // one stable prefix here so skip detection never depends on a translation.
+        normalizedTitle = normalizedTitle.replacingOccurrences(
+            of: #"(?i)^\s*(?:advertisement|advert|ad|sponsor(?:ed)?)\s*:\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        if normalizedTitle.isEmpty {
+            normalizedTitle = "sponsor message"
+        }
+        return "advertisement: \(normalizedTitle)"
     }
     
 


### PR DESCRIPTION
### Motivation
- Reduce chapter density so AI-generated chapters represent broad topic blocks rather than many small, short segments.
- Ensure advertisement blocks are reliably identified and represented as full chapters that can be skipped, across all supported languages.
- Give the model more context to avoid spurious boundaries by increasing chunk budgets and reducing per-chunk boundaries.

### Description
- Lowered the per-chunk chapter limit by changing `maxChaptersPerChunk` from `4` to `2` to prefer broad topic boundaries (`Raul/Features/Chapters/Models/AIChapter.swift`).
- Added a new `TranscriptAIChapter` generable struct with an `isAdvertisement: Bool` field and switched generation to produce that type instead of the previous `AIChapter` to surface ad classification to the app.
- Strengthened generation instructions to request sparse, 8–15 minute broad topic blocks, treat ads as exceptions, and require ad boundaries to span complete uninterrupted advertisement blocks (including across chunk boundaries).
- Increased transcript chunk budgets (`chunkBudget` from `1600`->`2400` on newer platforms, and `800`->`1600` on older platforms) and added `normalizedTranscriptChapterTitle` to enforce a language-independent `advertisement: ` prefix and a fallback title.

### Testing
- Ran `git diff --check`, which succeeded without whitespace or diff errors.
- Verified repository state with `git status --short` and committed the change with message `Generate broader AI podcast chapters` (commit `d278578`).
- Attempted `xcodebuild -project 'Up Next.xcodeproj' -scheme UpNext -showdestinations` but Xcode tooling is unavailable in this Linux container so the build destination check could not be run.
- Attempted to submit PR metadata via the local `make_pr` helper but the environment's `mcp` import/path prevented the helper from running; this is an environment limitation and did not affect the code changes or commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a984befe63c8320b82c952cb72c890c)