### PR TITLE
Transcribe more episodes, picked from every playlist

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -8743,12 +8743,12 @@
         }
       }
     },
-    "Use \"Only while charging\" if you want automatic local transcription to wait for external power. While the app is open it reacts to charging changes, and in the background it can pick up eligible Up Next episodes once power is available." : {
+    "Use \"Only while charging\" if you want automatic local transcription to wait for external power. While the app is open it reacts to charging changes, and in the background it works through your playlists whenever the device has a free moment." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verwende „Nur während des Ladevorgangs“, wenn die automatische lokale Transkription auf externe Stromversorgung warten soll. Während die App geöffnet ist, reagiert sie auf Ladeänderungen. Im Hintergrund kann sie geeignete „Als Nächstes“-Episoden aufnehmen, sobald Strom verfügbar ist."
+            "value" : "Verwende „Nur während des Ladevorgangs“, wenn die automatische lokale Transkription auf externe Stromversorgung warten soll. Während die App geöffnet ist, reagiert sie auf Ladeänderungen. Im Hintergrund arbeitet sie deine Playlists ab, sobald das Gerät einen freien Moment hat."
           }
         }
       }
@@ -9014,12 +9014,12 @@
         }
       }
     },
-    "When enabled, the app can start on-device transcription automatically after downloads finish. Feed-provided transcripts are still preferred when available." : {
+    "When enabled, the app can start on-device transcription automatically after downloads finish. Podcasts that publish their own transcripts are never transcribed on device — their transcript is imported instead." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wenn diese Option aktiviert ist, kann die App die Transkription auf dem Gerät automatisch starten, nachdem Downloads abgeschlossen sind. Vom Feed bereitgestellte Transkripte werden weiterhin bevorzugt, wenn sie verfügbar sind."
+            "value" : "Wenn diese Option aktiviert ist, kann die App die Transkription auf dem Gerät automatisch starten, nachdem Downloads abgeschlossen sind. Podcasts, die eigene Transkripte veröffentlichen, werden nie auf dem Gerät transkribiert — ihr Transkript wird stattdessen importiert."
           }
         }
       }

--- a/Raul/App/AppDelegate.swift
+++ b/Raul/App/AppDelegate.swift
@@ -232,31 +232,72 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         playbackStateBackgroundTaskID = .invalid
     }
 
+    /// Keeps the automatic transcription pass armed.
+    ///
+    /// The task used to be scheduled only when the user had switched on "only
+    /// while charging" — the default is off, so on most devices it was never
+    /// scheduled at all. It is now armed whenever transcriptions are on, and the
+    /// charging setting decides the request's power requirement instead.
     static func scheduleAutomaticTranscriptionProcessingIfNeeded() async {
         let settingsActor = PodcastSettingsModelActor(modelContainer: ModelContainerManager.shared.container)
-        let automaticTranscriptionsEnabled = await settingsActor.getAutomaticOnDeviceTranscriptionsEnabled()
-        let requiresCharging = await settingsActor.getAutomaticOnDeviceTranscriptionsRequiresCharging()
+        let transcriptionsEnabled = await settingsActor.getTranscriptionsEnabled()
 
-        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundTaskConfiguration.automaticTranscriptionIdentifier)
-
-        guard automaticTranscriptionsEnabled, requiresCharging else {
+        guard transcriptionsEnabled else {
+            BGTaskScheduler.shared.cancel(
+                taskRequestWithIdentifier: BackgroundTaskConfiguration.automaticTranscriptionIdentifier
+            )
             CrashBreadcrumbs.shared.record(
                 "automatic_transcription_background_task_not_scheduled",
-                details: "enabled=\(automaticTranscriptionsEnabled),requires_charging=\(requiresCharging)"
+                details: "transcriptions_enabled=false"
             )
             return
+        }
+
+        let automaticTranscriptionsEnabled = await settingsActor.getAutomaticOnDeviceTranscriptionsEnabled()
+        // Without the analyzer the pass only imports feed-provided transcripts,
+        // which is a small download and does not need external power.
+        let requiresCharging = automaticTranscriptionsEnabled
+            && await settingsActor.getAutomaticOnDeviceTranscriptionsRequiresCharging()
+
+        // Never cancel-and-resubmit a pending request. The app backgrounds many
+        // times a day and every resubmit pushed `earliestBeginDate` out again, so
+        // on a phone that gets picked up regularly the task kept sliding and
+        // never became eligible.
+        let pendingRequest = await BGTaskScheduler.shared.pendingTaskRequests().first {
+            $0.identifier == BackgroundTaskConfiguration.automaticTranscriptionIdentifier
+        }
+        if let pendingRequest {
+            let pendingRequiresExternalPower = (pendingRequest as? BGProcessingTaskRequest)?
+                .requiresExternalPower
+            guard pendingRequiresExternalPower != nil,
+                  pendingRequiresExternalPower != requiresCharging else {
+                CrashBreadcrumbs.shared.record(
+                    "automatic_transcription_background_task_already_scheduled"
+                )
+                return
+            }
+            // The charging setting changed since the request was submitted, so
+            // replace it with one that matches.
+            BGTaskScheduler.shared.cancel(
+                taskRequestWithIdentifier: BackgroundTaskConfiguration.automaticTranscriptionIdentifier
+            )
         }
 
         CrashBreadcrumbs.shared.record("automatic_transcription_background_task_schedule_requested")
         BasicLogger.shared.log("schedule automaticTranscriptionProcessing")
         let request = BGProcessingTaskRequest(identifier: BackgroundTaskConfiguration.automaticTranscriptionIdentifier)
-        request.requiresExternalPower = true
+        request.requiresExternalPower = requiresCharging
+        // Feed-provided transcripts are downloaded when a connection happens to
+        // be there; the analyzer works offline, so this must not be required.
         request.requiresNetworkConnectivity = false
         request.earliestBeginDate = Date(timeIntervalSinceNow: BackgroundTaskConfiguration.automaticTranscriptionInterval)
 
         do {
             try BGTaskScheduler.shared.submit(request)
-            CrashBreadcrumbs.shared.record("automatic_transcription_background_task_scheduled")
+            CrashBreadcrumbs.shared.record(
+                "automatic_transcription_background_task_scheduled",
+                details: "requires_external_power=\(requiresCharging)"
+            )
         } catch {
             CrashBreadcrumbs.shared.record(
                 "automatic_transcription_background_task_schedule_failed",
@@ -297,7 +338,28 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 task.setTaskCompleted(success: false)
                 return
             }
-            CrashBreadcrumbs.shared.record("feed_processing_background_task_completed")
+
+            // Feeds were just refreshed, so any transcript a podcast published
+            // is known now. Importing those here costs a few small downloads and
+            // spares the analyzer the episodes it never needed to run on.
+            // `TranscriptionManager.shared` builds itself on the main actor, so
+            // reach it from there: this task can be the first thing to touch it
+            // in a background launch of the process.
+            let transcriptionManager = await MainActor.run { TranscriptionManager.shared }
+            let importedTranscriptCount = await transcriptionManager
+                .runAutomaticTranscriptionsFromPlaylists(
+                    allowOnDeviceFallback: false,
+                    episodeLimit: BackgroundTaskConfiguration.feedProcessingTranscriptImportLimit,
+                    budget: BackgroundTaskConfiguration.feedProcessingTranscriptImportBudget
+                )
+            guard Task.isCancelled == false else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            CrashBreadcrumbs.shared.record(
+                "feed_processing_background_task_completed",
+                details: "imported_transcripts=\(importedTranscriptCount)"
+            )
             task.setTaskCompleted(success: true)
         }
 
@@ -322,17 +384,29 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 return
             }
 
-            let didProcess = await TranscriptionManager.shared.runAutomaticTranscriptionsFromUpNextUntilIdle(
-                allowOnDeviceFallback: true
-            )
+            // Work through several episodes per launch instead of one: iOS hands
+            // out these windows sparingly, and a single episode left most of the
+            // granted time unused.
+            let transcriptionManager = await MainActor.run { TranscriptionManager.shared }
+            let processedCount = await transcriptionManager
+                .runAutomaticTranscriptionsFromPlaylists(
+                    allowOnDeviceFallback: true,
+                    episodeLimit: BackgroundTaskConfiguration.automaticTranscriptionBackgroundEpisodeLimit,
+                    budget: BackgroundTaskConfiguration.automaticTranscriptionBackgroundBudget
+                )
             CrashBreadcrumbs.shared.record(
                 "automatic_transcription_background_task_completed",
-                details: "did_process=\(didProcess)"
+                details: "processed_count=\(processedCount)"
             )
             guard Task.isCancelled == false else {
                 task.setTaskCompleted(success: false)
                 return
             }
+
+            // Re-arm again now that the launched request is definitely consumed.
+            // No-ops when the request submitted at the start of the pass is still
+            // pending, so this only covers the case where it was not.
+            await Self.scheduleAutomaticTranscriptionProcessingIfNeeded()
             task.setTaskCompleted(success: true)
         }
 

--- a/Raul/App/RaulApp.swift
+++ b/Raul/App/RaulApp.swift
@@ -26,7 +26,19 @@ enum BackgroundTaskConfiguration {
     static let feedProcessingInterval: TimeInterval = 60 * 60
     static let nightlyStorageCleanupInterval: TimeInterval = 60 * 60 * 24
     static let weeklyStorageCleanupFallbackInterval: TimeInterval = 60 * 60 * 24 * 7
-    static let automaticTranscriptionInterval: TimeInterval = 60 * 15
+    /// Floor for the automatic transcription pass. The request is a floor, not a
+    /// schedule — iOS still picks the moment — so a short one just makes the task
+    /// eligible sooner and gets more episodes transcribed per day.
+    static let automaticTranscriptionInterval: TimeInterval = 60 * 5
+    /// Wall-clock budget for one background transcription pass. Checked before
+    /// starting another episode, never mid-analysis.
+    static let automaticTranscriptionBackgroundBudget: TimeInterval = 60 * 20
+    /// Upper bound on episodes handled in one background pass.
+    static let automaticTranscriptionBackgroundEpisodeLimit = 6
+    /// Feed processing rides along by importing published transcripts for
+    /// playlist episodes. Cheap downloads only — it never starts the analyzer.
+    static let feedProcessingTranscriptImportBudget: TimeInterval = 60
+    static let feedProcessingTranscriptImportLimit = 8
     static let lastStorageCleanupKey = "LastStorageCleanup"
     static let lastForegroundDownloadCleanupKey = "LastForegroundDownloadCleanup"
     static let foregroundDownloadCleanupMinimumInterval: TimeInterval = 60 * 60 * 12
@@ -692,7 +704,8 @@ struct RaulApp: App {
             return
         }
         CrashBreadcrumbs.shared.record("automatic_transcription_sweep_started", details: reason)
-        let startedEpisodeURL = await TranscriptionManager.shared.processNextAutomaticTranscriptionFromUpNext()
+        let startedEpisodeURL = await TranscriptionManager.shared
+            .processNextAutomaticTranscriptionFromPlaylists()
         if let startedEpisodeURL {
             CrashBreadcrumbs.shared.record("automatic_transcription_sweep_started_episode", details: startedEpisodeURL.absoluteString)
             BasicLogger.shared.log("automatic transcription sweep (\(reason)) started for \(startedEpisodeURL.absoluteString)")
@@ -865,6 +878,12 @@ private struct RootWindowView: View {
                         try? await Task.sleep(for: .seconds(8))
                         guard Task.isCancelled == false else { return }
                         await RaulApp.runAutomaticTranscriptionSweep(reason: "launch")
+#if canImport(UIKit)
+                        // Arm the background pass at launch instead of waiting
+                        // for the first background transition. It leaves an
+                        // already pending request alone.
+                        await AppDelegate.scheduleAutomaticTranscriptionProcessingIfNeeded()
+#endif
                     }
                 }
                 .task {

--- a/Raul/Features/Settings/Views/PodcastSettingsView.swift
+++ b/Raul/Features/Settings/Views/PodcastSettingsView.swift
@@ -851,6 +851,13 @@ struct PodcastSettingsView: View {
                     set: {
                         settings.enableTranscriptions = $0
                         saveAndNotify()
+#if canImport(UIKit)
+                        // Switching transcriptions on or off decides whether the
+                        // background pass stays armed at all.
+                        Task {
+                            await AppDelegate.scheduleAutomaticTranscriptionProcessingIfNeeded()
+                        }
+#endif
                     }
                 )
             )

--- a/Raul/Features/Settings/Views/TranscriptionSettingsView.swift
+++ b/Raul/Features/Settings/Views/TranscriptionSettingsView.swift
@@ -19,6 +19,16 @@ struct TranscriptionSettingsView: View {
         defaultSettings.first
     }
 
+    /// Re-arms the background transcription pass so a changed setting takes
+    /// effect now instead of at the next background transition.
+    private func rescheduleAutomaticTranscriptionProcessing() {
+#if canImport(UIKit)
+        Task {
+            await AppDelegate.scheduleAutomaticTranscriptionProcessingIfNeeded()
+        }
+#endif
+    }
+
     var body: some View {
         List {
             Section("On-Device Transcription") {
@@ -31,6 +41,7 @@ struct TranscriptionSettingsView: View {
                                 globalSettings.enableAutomaticOnDeviceTranscriptions = newValue
                                 context.saveIfNeeded()
                                 NotificationCenter.default.post(name: .podcastSettingsDidChange, object: nil)
+                                rescheduleAutomaticTranscriptionProcessing()
                             }
                         )
                     )
@@ -44,6 +55,7 @@ struct TranscriptionSettingsView: View {
                                 globalSettings.limitAutomaticOnDeviceTranscriptionsToCharging = newValue
                                 context.saveIfNeeded()
                                 NotificationCenter.default.post(name: .podcastSettingsDidChange, object: nil)
+                                rescheduleAutomaticTranscriptionProcessing()
                             }
                         )
                     )
@@ -80,10 +92,10 @@ struct TranscriptionSettingsView: View {
                 LabeledContent("Supported Models") {
                     Text(supportedLocales.isEmpty ? "Loading…" : "\(supportedLocales.count)")
                 }
-                Text("When enabled, the app can start on-device transcription automatically after downloads finish. Feed-provided transcripts are still preferred when available.")
+                Text("When enabled, the app can start on-device transcription automatically after downloads finish. Podcasts that publish their own transcripts are never transcribed on device — their transcript is imported instead.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text("Use \"Only while charging\" if you want automatic local transcription to wait for external power. While the app is open it reacts to charging changes, and in the background it can pick up eligible Up Next episodes once power is available.")
+                Text("Use \"Only while charging\" if you want automatic local transcription to wait for external power. While the app is open it reacts to charging changes, and in the background it works through your playlists whenever the device has a free moment.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Text("Models are language-specific on-device speech assets. The app uses the episode language when available and falls back to the current device locale.")

--- a/Raul/Shared/Actors/EpisodeActor.swift
+++ b/Raul/Shared/Actors/EpisodeActor.swift
@@ -1253,11 +1253,28 @@ actor EpisodeActor {
             return
         }
 
+        // A podcast that publishes transcripts for its other episodes publishes
+        // one for this episode too, usually within a day of release. Running the
+        // analyzer automatically would spend minutes of CPU and battery on a
+        // transcript the next feed refresh imports for free. A transcription the
+        // user asked for still goes ahead.
+        if origin == .automatic, podcastPublishesTranscripts(for: episode) {
+            return
+        }
+
         let transcriptionManager = await MainActor.run { TranscriptionManager.shared }
         _ = await transcriptionManager.enqueueTranscription(
             episodeURL: episodeURL,
             origin: origin
         )
+    }
+
+    /// Whether the episode's podcast ships transcript files with its feed.
+    func podcastPublishesTranscripts(for episode: Episode) -> Bool {
+        guard let podcast = episode.podcast else { return false }
+        return (podcast.episodes ?? []).contains { candidate in
+            candidate.externalFiles.contains { $0.category == .transcript }
+        }
     }
 
     private func isDeviceConnectedToPower() async -> Bool {
@@ -1290,14 +1307,6 @@ actor EpisodeActor {
 #endif
     }
 
-    func isReadyForAutomaticTranscription(episodeURL: URL) async -> Bool {
-        let settingsActor = PodcastSettingsModelActor(modelContainer: modelContainer)
-        guard await settingsActor.getTranscriptionsEnabled() else { return false }
-        guard let episode = await fetchEpisode(byURL: episodeURL) else { return false }
-        guard episode.url != nil else { return false }
-        guard episode.hasLoadedTranscript == false else { return false }
-        return episode.metaData?.calculatedIsAvailableLocally == true
-    }
     
     func decodeTranscription(_ transcription: String) -> [TranscriptLineAndTime] {
         print("decodeTranscription")

--- a/Raul/Shared/Actors/TranscriptionManager.swift
+++ b/Raul/Shared/Actors/TranscriptionManager.swift
@@ -87,10 +87,13 @@ actor TranscriptionManager {
     private var tasks: [URL: Task<Void, Never>] = [:]
     private var taskOrigins: [URL: TranscriptionStartOrigin] = [:]
     private var episodeSnapshots: [URL: TranscriptionEpisodeSnapshot] = [:]
-    private var automaticScanCursor = 0
     private var lastAutomaticSweepAt: Date?
-    private let automaticScanLimit = 12
+    /// Episodes an automatic attempt could not start, with the time they may be
+    /// tried again. Without it a single broken episode swallows every sweep.
+    private var automaticRetryBlockedUntil: [URL: Date] = [:]
+    private let automaticScanLimit = AutomaticTranscriptionCandidateProvider.defaultLimit
     private let automaticSweepCooldown: TimeInterval = 30
+    private let automaticRetryCooldown: TimeInterval = 60 * 60 * 6
 
     // Serializes the heavy transcription work so at most one Speech analyzer runs at a
     // time. Two concurrent analyzers double the e-core pressure, memory, and the odds of
@@ -347,92 +350,137 @@ actor TranscriptionManager {
         }
     }
 
-    func processNextAutomaticTranscriptionFromUpNext(
-        allowOnDeviceFallback: Bool = true
+    /// Starts the next automatic transcription picked from the user's playlists.
+    ///
+    /// - Parameters:
+    ///   - allowOnDeviceFallback: When `false`, only feed-provided transcripts
+    ///     are imported and the analyzer is never started.
+    ///   - respectSweepCooldown: Foreground sweeps fire on app activation and on
+    ///     every power-state change, so they throttle each other. A background
+    ///     pass is a rare, deliberate opportunity and passes `false`.
+    ///   - deadline: Stops the search for a startable episode. Skipping a
+    ///     candidate can mean a failed transcript download, so a long candidate
+    ///     list must not be allowed to outlive the caller's window.
+    /// - Returns: The episode that was handled, or `nil` when nothing was left
+    ///   to do.
+    func processNextAutomaticTranscriptionFromPlaylists(
+        allowOnDeviceFallback: Bool = true,
+        respectSweepCooldown: Bool = true,
+        deadline: Date? = nil
     ) async -> URL? {
         guard tasks.isEmpty else { return nil }
         let now = Date()
-        if let lastAutomaticSweepAt,
+        if respectSweepCooldown,
+           let lastAutomaticSweepAt,
            now.timeIntervalSince(lastAutomaticSweepAt) < automaticSweepCooldown {
             return nil
         }
         lastAutomaticSweepAt = now
 
         let settingsActor = PodcastSettingsModelActor(modelContainer: container)
-        guard await settingsActor.getAutomaticOnDeviceTranscriptionsEnabled() else {
+        guard await settingsActor.getTranscriptionsEnabled() else {
             return nil
         }
 
-        let requiresCharging = await settingsActor.getAutomaticOnDeviceTranscriptionsRequiresCharging()
-        let isConnectedToPower = requiresCharging ? await isDeviceConnectedToPower() : true
-        if isConnectedToPower == false {
-            return nil
+        // Importing a published transcript is a small download and stays allowed
+        // even when the user switched the on-device analyzer off or is off power.
+        var allowsAnalyzer = allowOnDeviceFallback
+        if allowsAnalyzer {
+            allowsAnalyzer = await settingsActor.getAutomaticOnDeviceTranscriptionsEnabled()
+        }
+        if allowsAnalyzer, await settingsActor.getAutomaticOnDeviceTranscriptionsRequiresCharging() {
+            allowsAnalyzer = await isDeviceConnectedToPower()
         }
 
-        let playlistActor: PlaylistModelActor
-        do {
-            playlistActor = try PlaylistModelActor(modelContainer: container)
-        } catch {
-            return nil
-        }
+        automaticRetryBlockedUntil = automaticRetryBlockedUntil.filter { $0.value > now }
 
-        let upNextEpisodeURLs: [URL]
-        do {
-            upNextEpisodeURLs = try await playlistActor.orderedEpisodeURLs()
-        } catch {
-            return nil
-        }
-        guard upNextEpisodeURLs.isEmpty == false else { return nil }
+        let provider = AutomaticTranscriptionCandidateProvider(modelContainer: container)
+        let candidates = await provider.candidates(
+            limit: automaticScanLimit,
+            allowOnDeviceFallback: allowsAnalyzer,
+            excluding: Set(items.keys).union(automaticRetryBlockedUntil.keys)
+        )
+        guard candidates.isEmpty == false else { return nil }
 
         let episodeActor = EpisodeActor(modelContainer: container)
-        let scanCount = min(automaticScanLimit, upNextEpisodeURLs.count)
 
-        for offset in 0..<scanCount {
-            let index = (automaticScanCursor + offset) % upNextEpisodeURLs.count
-            let episodeURL = upNextEpisodeURLs[index]
-            guard items[episodeURL] == nil else { continue }
-            let wasReady = await episodeActor.isReadyForAutomaticTranscription(episodeURL: episodeURL)
-            guard wasReady else { continue }
+        for candidate in candidates {
+            if Task.isCancelled { return nil }
+            if let deadline, Date() >= deadline { return nil }
+            let episodeURL = candidate.episodeURL
 
             try? await episodeActor.transcribe(
                 episodeURL,
-                allowOnDeviceFallback: allowOnDeviceFallback,
+                allowOnDeviceFallback: candidate.source == .onDevice,
                 origin: .automatic
             )
-
-            automaticScanCursor = (index + 1) % upNextEpisodeURLs.count
 
             if tasks[episodeURL] != nil {
                 return episodeURL
             }
 
-            // If the episode stopped being "ready" after transcribe(), we likely imported
-            // a feed-provided transcript without spawning an on-device task.
-            let isStillReady = await episodeActor.isReadyForAutomaticTranscription(episodeURL: episodeURL)
-            if isStillReady == false {
+            // No analyzer job means the episode either got its transcript from
+            // the feed just now, or the attempt produced nothing. Re-read it in a
+            // fresh context: a stale one would still report the pre-import state.
+            let verifier = AutomaticTranscriptionCandidateProvider(modelContainer: container)
+            let remainingSource = await verifier.transcriptionSource(
+                for: episodeURL,
+                allowOnDeviceFallback: allowsAnalyzer
+            )
+            if remainingSource == nil {
                 return episodeURL
             }
+
+            // Still waiting. Park it so the next sweep spends its window on the
+            // following episode instead of retrying this one immediately.
+            automaticRetryBlockedUntil[episodeURL] = now.addingTimeInterval(automaticRetryCooldown)
         }
 
-        automaticScanCursor = (automaticScanCursor + scanCount) % upNextEpisodeURLs.count
         return nil
     }
 
-    func runAutomaticTranscriptionsFromUpNextUntilIdle(
-        allowOnDeviceFallback: Bool = true
-    ) async -> Bool {
-        guard let startedEpisodeURL = await processNextAutomaticTranscriptionFromUpNext(
-            allowOnDeviceFallback: allowOnDeviceFallback
-        ) else {
-            return false
+    /// Works through the playlists until the budget is spent, the episode limit
+    /// is reached, or nothing is left to transcribe.
+    ///
+    /// The budget is only checked before starting another episode: a running
+    /// analyzer is left alone so its transcript still gets written, and the
+    /// background task's expiration handler cancels it if iOS reclaims the time.
+    ///
+    /// - Returns: How many episodes were handled.
+    @discardableResult
+    func runAutomaticTranscriptionsFromPlaylists(
+        allowOnDeviceFallback: Bool = true,
+        episodeLimit: Int = 1,
+        budget: TimeInterval? = nil
+    ) async -> Int {
+        guard episodeLimit > 0 else { return 0 }
+        let deadline = budget.map { Date(timeIntervalSinceNow: $0) }
+        var processedCount = 0
+
+        while processedCount < episodeLimit {
+            if Task.isCancelled { break }
+            if let deadline, Date() >= deadline { break }
+            // Back-to-back analyzer runs heat the device up. Stop handing out
+            // more work once the system says it is under pressure; the next
+            // background pass picks up where this one stopped.
+            if processedCount > 0, SystemPressureGate.shared.isUnderPressure { break }
+
+            guard let episodeURL = await processNextAutomaticTranscriptionFromPlaylists(
+                allowOnDeviceFallback: allowOnDeviceFallback,
+                respectSweepCooldown: false,
+                deadline: deadline
+            ) else { break }
+
+            processedCount += 1
+
+            // Wait for the analyzer to finish before picking the next episode:
+            // two of them at once double e-core pressure and memory.
+            if let runningTask = tasks[episodeURL] {
+                await runningTask.value
+            }
         }
 
-        // Process at most one automatic job per invocation to keep background CPU bounded.
-        if let runningTask = tasks[startedEpisodeURL] {
-            await runningTask.value
-        }
-
-        return true
+        return processedCount
     }
 
     private func finish(episodeURL: URL, error: String) async {

--- a/Raul/Shared/Services/AutomaticTranscriptionCandidateProvider.swift
+++ b/Raul/Shared/Services/AutomaticTranscriptionCandidateProvider.swift
@@ -1,0 +1,216 @@
+//
+//  AutomaticTranscriptionCandidateProvider.swift
+//  Raul
+//
+//  Picks the episodes automatic transcription works on next.
+//
+
+import Foundation
+import SwiftData
+
+/// Where the transcript for an episode is expected to come from.
+enum AutomaticTranscriptionSource: String, Sendable {
+    /// The feed publishes a transcript file. Importing it costs one small
+    /// download, so it is always preferred over running the analyzer.
+    case publishedTranscript
+    /// Nobody publishes a transcript for this episode, so the on-device
+    /// analyzer is the only way to get one.
+    case onDevice
+}
+
+struct AutomaticTranscriptionCandidate: Sendable, Equatable {
+    let episodeURL: URL
+    let playlistTitle: String
+    let source: AutomaticTranscriptionSource
+}
+
+/// Selects transcription candidates from the user's playlists.
+///
+/// Selection walks the playlists the way the user sees them — the playlist they
+/// play from first, then the remaining visible playlists in their configured
+/// order — so the episodes closest to being played get a transcript first.
+/// Earlier revisions only ever looked at Up Next, which left everything queued
+/// in another playlist untranscribed.
+///
+/// Within that order the episodes whose feed already publishes a transcript come
+/// first: importing a published transcript takes seconds while the analyzer
+/// takes minutes, so a background window that starts with the cheap ones ends
+/// with more transcribed episodes.
+actor AutomaticTranscriptionCandidateProvider {
+    static let defaultLimit = 24
+    /// Upper bound on the episodes inspected per playlist. A smart playlist can
+    /// match a whole library, and deciding whether an episode is downloaded
+    /// touches the file system, so the scan stays near the top of each list.
+    static let maximumEpisodesScannedPerPlaylist = 200
+
+    private let modelContext: ModelContext
+    private let defaults: UserDefaults
+    /// `podcast.episodes` is a fault; resolving it once per podcast keeps a scan
+    /// over several playlists from faulting the same back catalog repeatedly.
+    private var podcastPublishesTranscriptsCache: [PersistentIdentifier: Bool] = [:]
+
+    init(modelContainer: ModelContainer, defaults: UserDefaults = .standard) {
+        self.modelContext = ModelContext(modelContainer)
+        self.defaults = defaults
+    }
+
+    /// Ordered transcription candidates across every visible playlist.
+    ///
+    /// - Parameters:
+    ///   - limit: Upper bound on the returned candidates.
+    ///   - allowOnDeviceFallback: When `false`, only episodes with a published
+    ///     transcript are returned, so the caller never starts the analyzer.
+    ///   - excludedEpisodeURLs: Episodes the caller already handled (running,
+    ///     finished, or parked after a failed attempt).
+    func candidates(
+        limit: Int = AutomaticTranscriptionCandidateProvider.defaultLimit,
+        allowOnDeviceFallback: Bool = true,
+        excluding excludedEpisodeURLs: Set<URL> = []
+    ) -> [AutomaticTranscriptionCandidate] {
+        guard limit > 0 else { return [] }
+
+        let playlists = orderedPlaylists()
+        guard playlists.isEmpty == false else { return [] }
+
+        var allEpisodes: [Episode]?
+        var seenEpisodeURLs = Set<URL>()
+        var publishedCandidates: [AutomaticTranscriptionCandidate] = []
+        var onDeviceCandidates: [AutomaticTranscriptionCandidate] = []
+
+        playlistScan: for playlist in playlists {
+            let episodes: [Episode]
+            if playlist.isSmartPlaylist {
+                if allEpisodes == nil {
+                    allEpisodes = (try? modelContext.fetch(FetchDescriptor<Episode>())) ?? []
+                }
+                episodes = SmartPlaylistEngine.episodes(from: allEpisodes ?? [], for: playlist)
+            } else {
+                episodes = orderedEntries(in: playlist.id).compactMap(\.episode)
+            }
+
+            let playlistTitle = playlist.displayTitle
+
+            for episode in episodes.prefix(Self.maximumEpisodesScannedPerPlaylist) {
+                guard let episodeURL = episode.url else { continue }
+                guard excludedEpisodeURLs.contains(episodeURL) == false else { continue }
+                guard seenEpisodeURLs.insert(episodeURL).inserted else { continue }
+                guard let source = transcriptionSource(
+                    for: episode,
+                    allowOnDeviceFallback: allowOnDeviceFallback
+                ) else { continue }
+
+                let candidate = AutomaticTranscriptionCandidate(
+                    episodeURL: episodeURL,
+                    playlistTitle: playlistTitle,
+                    source: source
+                )
+
+                switch source {
+                case .publishedTranscript:
+                    publishedCandidates.append(candidate)
+                case .onDevice:
+                    onDeviceCandidates.append(candidate)
+                }
+
+                if publishedCandidates.count + onDeviceCandidates.count >= limit {
+                    break playlistScan
+                }
+            }
+        }
+
+        return Array((publishedCandidates + onDeviceCandidates).prefix(limit))
+    }
+
+    /// Re-classifies a single episode, e.g. to check whether an attempt left it
+    /// waiting for another try.
+    func transcriptionSource(
+        for episodeURL: URL,
+        allowOnDeviceFallback: Bool = true
+    ) -> AutomaticTranscriptionSource? {
+        var descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.url == episodeURL }
+        )
+        descriptor.fetchLimit = 1
+        guard let episode = try? modelContext.fetch(descriptor).first else { return nil }
+        return transcriptionSource(for: episode, allowOnDeviceFallback: allowOnDeviceFallback)
+    }
+
+    // MARK: - Private helpers
+
+    private func transcriptionSource(
+        for episode: Episode,
+        allowOnDeviceFallback: Bool
+    ) -> AutomaticTranscriptionSource? {
+        guard episode.hasLoadedTranscript == false else { return nil }
+
+        if episode.externalFiles.contains(where: { $0.category == .transcript }) {
+            return .publishedTranscript
+        }
+
+        guard allowOnDeviceFallback else { return nil }
+
+        // A podcast that publishes transcripts for its other episodes publishes
+        // one for this episode too, usually within a day of release. Running the
+        // analyzer on it would spend minutes of CPU and battery on a transcript
+        // the next feed refresh brings in for free.
+        guard podcastPublishesTranscripts(episode) == false else { return nil }
+
+        // The analyzer reads the downloaded audio file; without it there is
+        // nothing to transcribe.
+        guard episode.metaData?.calculatedIsAvailableLocally == true else { return nil }
+
+        return .onDevice
+    }
+
+    private func podcastPublishesTranscripts(_ episode: Episode) -> Bool {
+        guard let podcast = episode.podcast else { return false }
+
+        let cacheKey = podcast.persistentModelID
+        if let cached = podcastPublishesTranscriptsCache[cacheKey] {
+            return cached
+        }
+
+        let publishesTranscripts = (podcast.episodes ?? []).contains { candidate in
+            candidate.externalFiles.contains { $0.category == .transcript }
+        }
+        podcastPublishesTranscriptsCache[cacheKey] = publishesTranscripts
+        return publishesTranscripts
+    }
+
+    /// Visible playlists in display order, with the playlist the user plays from
+    /// pulled to the front.
+    private func orderedPlaylists() -> [Playlist] {
+        let allPlaylists = (try? modelContext.fetch(FetchDescriptor<Playlist>())) ?? []
+        guard allPlaylists.isEmpty == false else { return [] }
+
+        var ordered = Playlist.visibleSorted(allPlaylists)
+        let selectedPlaylistID = Playlist.resolvePlaylistID(
+            from: defaults.string(forKey: PlaylistPreferenceKeys.selectedPlaylistID)
+        )
+
+        if let selectedPlaylistID,
+           let selectedIndex = ordered.firstIndex(where: { $0.id == selectedPlaylistID }),
+           selectedIndex > 0 {
+            let selected = ordered.remove(at: selectedIndex)
+            ordered.insert(selected, at: 0)
+        }
+
+        return ordered
+    }
+
+    /// Entries in storage order instead of sorting the relationship in memory:
+    /// SwiftData can invalidate a relationship object while another context
+    /// updates the playlist, and reading `order` from it then traps.
+    private func orderedEntries(in playlistID: UUID) -> [PlaylistEntry] {
+        let descriptor = FetchDescriptor<PlaylistEntry>(
+            predicate: #Predicate<PlaylistEntry> { entry in
+                entry.playlist?.id == playlistID
+            },
+            sortBy: [
+                SortDescriptor(\PlaylistEntry.order, order: .forward),
+                SortDescriptor(\PlaylistEntry.dateAdded, order: .forward)
+            ]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+}

--- a/UpNextTests/AutomaticTranscriptionCandidateProviderTests.swift
+++ b/UpNextTests/AutomaticTranscriptionCandidateProviderTests.swift
@@ -1,0 +1,273 @@
+import SwiftData
+import XCTest
+@testable import UpNext
+
+final class AutomaticTranscriptionCandidateProviderTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AutomaticTranscriptionCandidateProviderTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectory {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+        temporaryDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testCandidatesComeFromEveryPlaylistNotJustUpNext() async throws {
+        let fixture = try makeFixture()
+        let queued = try makeDownloadedEpisode(title: "Queued", in: fixture)
+        let other = try makeDownloadedEpisode(title: "Other", in: fixture)
+        try queue(queued, in: fixture.defaultPlaylist, fixture: fixture)
+        try queue(other, in: fixture.secondPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates()
+
+        XCTAssertEqual(
+            candidates.map(\.episodeURL),
+            [queued.url, other.url].compactMap { $0 }
+        )
+        XCTAssertEqual(candidates.map(\.source), [.onDevice, .onDevice])
+    }
+
+    func testPublishedTranscriptsAreOfferedBeforeOnDeviceWork() async throws {
+        let fixture = try makeFixture()
+        let onDevice = try makeDownloadedEpisode(title: "Needs analyzer", in: fixture)
+        let published = try makeDownloadedEpisode(title: "Has transcript", in: fixture)
+        published.externalFiles = [transcriptFile()]
+        try queue(onDevice, in: fixture.defaultPlaylist, fixture: fixture)
+        try queue(published, in: fixture.defaultPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates()
+
+        XCTAssertEqual(
+            candidates.map(\.episodeURL),
+            [published.url, onDevice.url].compactMap { $0 }
+        )
+        XCTAssertEqual(candidates.map(\.source), [.publishedTranscript, .onDevice])
+    }
+
+    func testOnDeviceCandidatesAreDroppedWhenTheAnalyzerIsNotAllowed() async throws {
+        let fixture = try makeFixture()
+        let onDevice = try makeDownloadedEpisode(title: "Needs analyzer", in: fixture)
+        let published = try makeDownloadedEpisode(title: "Has transcript", in: fixture)
+        published.externalFiles = [transcriptFile()]
+        try queue(onDevice, in: fixture.defaultPlaylist, fixture: fixture)
+        try queue(published, in: fixture.defaultPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates(allowOnDeviceFallback: false)
+
+        XCTAssertEqual(candidates.map(\.episodeURL), [published.url].compactMap { $0 })
+    }
+
+    func testEpisodesOfPodcastsThatPublishTranscriptsAreNeverTranscribedOnDevice() async throws {
+        let fixture = try makeFixture()
+        let podcast = Podcast(feed: URL(string: "https://example.com/feed.xml")!)
+        fixture.context.insert(podcast)
+
+        let withTranscript = try makeDownloadedEpisode(title: "Published", in: fixture)
+        withTranscript.externalFiles = [transcriptFile()]
+        withTranscript.podcast = podcast
+
+        let withoutTranscript = try makeDownloadedEpisode(title: "Not published yet", in: fixture)
+        withoutTranscript.podcast = podcast
+
+        try queue(withoutTranscript, in: fixture.defaultPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates()
+
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testEpisodesWithATranscriptAreNotCandidates() async throws {
+        let fixture = try makeFixture()
+        let transcribed = try makeDownloadedEpisode(title: "Transcribed", in: fixture)
+        let line = TranscriptLineAndTime(text: "Hello", startTime: 0)
+        fixture.context.insert(line)
+        transcribed.transcriptLines = [line]
+        try queue(transcribed, in: fixture.defaultPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates()
+
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testEpisodesThatAreNotDownloadedAreNotOnDeviceCandidates() async throws {
+        let fixture = try makeFixture()
+        let notDownloaded = Episode(
+            guid: "not-downloaded",
+            title: "Not downloaded",
+            url: URL(string: "https://example.com/not-downloaded.mp3")!
+        )
+        fixture.context.insert(notDownloaded)
+        try queue(notDownloaded, in: fixture.defaultPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates()
+
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testSelectedPlaylistIsScannedFirst() async throws {
+        let fixture = try makeFixture()
+        let queued = try makeDownloadedEpisode(title: "Queued", in: fixture)
+        let other = try makeDownloadedEpisode(title: "Other", in: fixture)
+        try queue(queued, in: fixture.defaultPlaylist, fixture: fixture)
+        try queue(other, in: fixture.secondPlaylist, fixture: fixture)
+        fixture.defaults.set(
+            fixture.secondPlaylist.id.uuidString,
+            forKey: PlaylistPreferenceKeys.selectedPlaylistID
+        )
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates()
+
+        XCTAssertEqual(
+            candidates.map(\.episodeURL),
+            [other.url, queued.url].compactMap { $0 }
+        )
+    }
+
+    func testExcludedEpisodesAreSkipped() async throws {
+        let fixture = try makeFixture()
+        let first = try makeDownloadedEpisode(title: "First", in: fixture)
+        let second = try makeDownloadedEpisode(title: "Second", in: fixture)
+        try queue(first, in: fixture.defaultPlaylist, fixture: fixture)
+        try queue(second, in: fixture.defaultPlaylist, fixture: fixture)
+
+        let provider = AutomaticTranscriptionCandidateProvider(
+            modelContainer: fixture.container,
+            defaults: fixture.defaults
+        )
+        let candidates = await provider.candidates(
+            excluding: [try XCTUnwrap(first.url)]
+        )
+
+        XCTAssertEqual(candidates.map(\.episodeURL), [second.url].compactMap { $0 })
+    }
+
+    // MARK: - Fixture
+
+    struct Fixture {
+        let container: ModelContainer
+        let context: ModelContext
+        let defaults: UserDefaults
+        let defaultPlaylist: Playlist
+        let secondPlaylist: Playlist
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Podcast.self,
+            PodcastMetaData.self,
+            Episode.self,
+            EpisodeMetaData.self,
+            Playlist.self,
+            PlaylistEntry.self,
+            TranscriptLineAndTime.self,
+            Marker.self,
+            Bookmark.self,
+            RateSegment.self,
+            PlaySession.self,
+            ListeningStat.self,
+            PlaySessionSummary.self,
+            TranscriptionRecord.self,
+            configurations: configuration
+        )
+        let context = ModelContext(container)
+        let defaultPlaylist = Playlist.ensureDefaultQueue(in: context)
+
+        let secondPlaylist = Playlist()
+        secondPlaylist.title = "Later"
+        secondPlaylist.deleteable = true
+        secondPlaylist.hidden = false
+        secondPlaylist.sortIndex = 1
+        secondPlaylist.kind = .manual
+        context.insert(secondPlaylist)
+        try context.save()
+
+        let suiteName = "AutomaticTranscriptionCandidateProviderTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        return Fixture(
+            container: container,
+            context: context,
+            defaults: defaults,
+            defaultPlaylist: defaultPlaylist,
+            secondPlaylist: secondPlaylist
+        )
+    }
+
+    /// A side-loaded episode backed by a real file, so `calculatedIsAvailableLocally`
+    /// reports the episode as downloaded.
+    private func makeDownloadedEpisode(title: String, in fixture: Fixture) throws -> Episode {
+        let fileURL = temporaryDirectory.appendingPathComponent("\(UUID().uuidString).mp3")
+        try Data("audio".utf8).write(to: fileURL)
+
+        let episode = Episode(
+            guid: "\(title)-\(UUID().uuidString)",
+            title: title,
+            url: fileURL,
+            source: .sideLoaded
+        )
+        fixture.context.insert(episode)
+        try fixture.context.save()
+
+        XCTAssertEqual(episode.metaData?.calculatedIsAvailableLocally, true)
+        return episode
+    }
+
+    private func transcriptFile() -> ExternalFile {
+        ExternalFile(
+            url: "https://example.com/transcript.vtt",
+            category: .transcript,
+            source: nil,
+            fileType: "text/vtt"
+        )
+    }
+
+    private func queue(_ episode: Episode, in playlist: Playlist, fixture: Fixture) throws {
+        let order = (playlist.items?.count ?? 0)
+        let entry = PlaylistEntry(episode: episode, order: order)
+        fixture.context.insert(entry)
+        entry.playlist = playlist
+        try fixture.context.save()
+    }
+}


### PR DESCRIPTION
Automatic transcription only ever looked at Up Next, ran one episode per
background launch, and — because the background task was scheduled only
when "only while charging" was on, which is off by default — usually was
never scheduled at all.

Scheduling:
- Arm the processing task whenever transcriptions are enabled and let the
  charging setting decide `requiresExternalPower` instead of gating the
  scheduling itself.
- Leave a pending request alone rather than cancel-and-resubmit on every
  background transition, which kept pushing `earliestBeginDate` out.
- Drop the floor from 15 to 5 minutes, arm at launch and when the
  transcription settings change, and re-arm after a pass finishes.
- Work through several episodes per launch under a wall-clock budget,
  stopping early when the system reports thermal or memory pressure.
- Let the hourly feed-processing task import published transcripts for
  playlist episodes; it never starts the analyzer.

Selection:
- Add AutomaticTranscriptionCandidateProvider, which walks every visible
  playlist (the one the user plays from first) instead of Up Next only,
  and offers episodes with a published transcript before ones that need
  the analyzer.
- Never run the analyzer automatically for a podcast that publishes its
  own transcripts; import the published transcript instead.
- Park an episode that could not be started for six hours so one broken
  episode cannot swallow every sweep.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E7w5HCvGQe3ekaCZHiHyLc